### PR TITLE
chore(labels): add orchestration:plan-approved label

### DIFF
--- a/.github/.labels.json
+++ b/.github/.labels.json
@@ -142,5 +142,11 @@
         "color": "5319e7",
         "default": false,
         "description": "User story"
+    },
+    {
+        "name": "orchestration:plan-approved",
+        "color": "0E8A16",
+        "default": false,
+        "description": "Application plan approved - ready for epic creation"
     }
 ]


### PR DESCRIPTION
## Summary

- Adds `orchestration:plan-approved` label definition to `.github/.labels.json` to sync the local label manifest with the label already present on the remote repository
- The label (`#0E8A16`, "Application plan approved - ready for epic creation") was created on the GitHub repo during project-setup but was missing from the local labels file

## Context

This is the **post-script-complete** event for the `project-setup` dynamic workflow. The label already exists on the remote and is applied to Issue #5 (the Application Plan). This PR ensures the local `.labels.json` stays in sync.